### PR TITLE
OS path for Cache was incorrectly modified to upper case

### DIFF
--- a/src/cache.py
+++ b/src/cache.py
@@ -152,7 +152,7 @@ class S3Cache(Cache):
 
 def get_cache(**kw):
 	mode = os.getenv('CACHE_MODE','').upper()
-	path = os.getenv('CACHE_PATH','').upper()
+	path = os.getenv('CACHE_PATH','')
 	if mode == 'DISK':
 		return DiskCache(path)
 	elif mode == 'S3':


### PR DESCRIPTION
Running locally I got an error after uploading an PDF. 
```
FileNotFoundError: [Errno 2] No such file or directory: '/CODE/DATA/CACHE/...
```
* Removed ".upper()" on os path